### PR TITLE
Fix curios integration for forge 31.1.10+

### DIFF
--- a/src/main/resources/META-INF/mods.toml
+++ b/src/main/resources/META-INF/mods.toml
@@ -28,7 +28,7 @@ description="Adds a simple backpack to store more items"
 [[dependencies.backpacked]]
     modId="curios"
     mandatory=false
-    versionRange="[4.0.1.0,)"
+    versionRange="[1.16.3-4.0.1.0,)"
     ordering="AFTER"
     side="BOTH"
 [[dependencies.backpacked]]


### PR DESCRIPTION
This issue is only present with Minecraft Forge 36.1.10 or newer, as versionRange is now required for optional dependencies. I added the Minecraft version before the Curios version as that is how Curios does versions. This fixes #48 

This is also my first pull request so if anything's wrong, please let me know.