### PR TITLE
🐛 Fix Fabric resource warning noise

### DIFF
--- a/common/src/main/resources/assets/backpacked/models/backpacked/bamboo_basket.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/bamboo_basket.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"bamboo_basket": "backpacked:backpack/bamboo_basket"
+		"bamboo_basket": "backpacked:backpack/bamboo_basket",
+		"particle": "#bamboo_basket"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/bamboo_basket_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/bamboo_basket_straps.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"bamboo_basket": "backpacked:backpack/bamboo_basket"
+		"bamboo_basket": "backpacked:backpack/bamboo_basket",
+		"particle": "#bamboo_basket"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/cardboard_box.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/cardboard_box.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"cardboard_box": "backpacked:backpack/cardboard_box"
+		"cardboard_box": "backpacked:backpack/cardboard_box",
+		"particle": "#cardboard_box"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/cardboard_box_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/cardboard_box_straps.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"cardboard_box": "backpacked:backpack/cardboard_box"
+		"cardboard_box": "backpacked:backpack/cardboard_box",
+		"particle": "#cardboard_box"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/classic.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/classic.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"classic": "backpacked:backpack/classic"
+		"classic": "backpacked:backpack/classic",
+		"particle": "#classic"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/classic_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/classic_straps.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"classic": "backpacked:backpack/classic"
+		"classic": "backpacked:backpack/classic",
+		"particle": "#classic"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/cogwheel.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/cogwheel.json
@@ -3,7 +3,8 @@
     "loader": "framework:open_model",
     "fabric:type": "framework:open_model",
 	"textures": {
-		"cogwheel": "backpacked:backpack/cogwheel"
+		"cogwheel": "backpacked:backpack/cogwheel",
+		"particle": "#cogwheel"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/cogwheel_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/cogwheel_straps.json
@@ -3,7 +3,8 @@
     "loader": "framework:open_model",
     "fabric:type": "framework:open_model",
 	"textures": {
-		"cogwheel": "backpacked:backpack/cogwheel"
+		"cogwheel": "backpacked:backpack/cogwheel",
+		"particle": "#cogwheel"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/cogwheel_wheel.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/cogwheel_wheel.json
@@ -3,7 +3,8 @@
     "loader": "framework:open_model",
     "fabric:type": "framework:open_model",
 	"textures": {
-		"cogwheel": "backpacked:backpack/cogwheel"
+		"cogwheel": "backpacked:backpack/cogwheel",
+		"particle": "#cogwheel"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/end_crystal.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/end_crystal.json
@@ -3,7 +3,8 @@
     "loader": "framework:open_model",
     "fabric:type": "framework:open_model",
 	"textures": {
-		"end_crystal": "backpacked:backpack/end_crystal"
+		"end_crystal": "backpacked:backpack/end_crystal",
+		"particle": "#end_crystal"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/end_crystal_frame.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/end_crystal_frame.json
@@ -4,7 +4,8 @@
     "fabric:type": "framework:open_model",
 	"texture_size": [32, 16],
 	"textures": {
-		"end_crystal": "backpacked:backpack/end_crystal"
+		"end_crystal": "backpacked:backpack/end_crystal",
+		"particle": "#end_crystal"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/end_crystal_inner.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/end_crystal_inner.json
@@ -4,7 +4,8 @@
     "fabric:type": "framework:open_model",
 	"texture_size": [32, 16],
 	"textures": {
-		"end_crystal": "backpacked:backpack/end_crystal"
+		"end_crystal": "backpacked:backpack/end_crystal",
+		"particle": "#end_crystal"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/end_crystal_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/end_crystal_straps.json
@@ -3,7 +3,8 @@
     "loader": "framework:open_model",
     "fabric:type": "framework:open_model",
 	"textures": {
-		"end_crystal": "backpacked:backpack/end_crystal"
+		"end_crystal": "backpacked:backpack/end_crystal",
+		"particle": "#end_crystal"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/honey_jar.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/honey_jar.json
@@ -2,7 +2,8 @@
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"texture_size": [32, 16],
 	"textures": {
-        "1": "backpacked:backpack/honey_jar"
+        "1": "backpacked:backpack/honey_jar",
+		"particle": "#1"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/honey_jar_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/honey_jar_straps.json
@@ -2,7 +2,8 @@
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"texture_size": [32, 16],
 	"textures": {
-		"1": "backpacked:backpack/honey_jar"
+		"1": "backpacked:backpack/honey_jar",
+		"particle": "#1"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/mini_chest.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/mini_chest.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"mini_chest": "backpacked:backpack/mini_chest"
+		"mini_chest": "backpacked:backpack/mini_chest",
+		"particle": "#mini_chest"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/mini_chest_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/mini_chest_straps.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"mini_chest": "backpacked:backpack/mini_chest"
+		"mini_chest": "backpacked:backpack/mini_chest",
+		"particle": "#mini_chest"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/piglin_pack.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/piglin_pack.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"piglin_pack": "backpacked:backpack/piglin_pack"
+		"piglin_pack": "backpacked:backpack/piglin_pack",
+		"particle": "#piglin_pack"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/piglin_pack_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/piglin_pack_straps.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"piglin_pack": "backpacked:backpack/piglin_pack"
+		"piglin_pack": "backpacked:backpack/piglin_pack",
+		"particle": "#piglin_pack"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/rocket.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/rocket.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"rocket": "backpacked:backpack/rocket"
+		"rocket": "backpacked:backpack/rocket",
+		"particle": "#rocket"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/rocket_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/rocket_straps.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"rocket": "backpacked:backpack/rocket"
+		"rocket": "backpacked:backpack/rocket",
+		"particle": "#rocket"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/sheep_plush.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/sheep_plush.json
@@ -3,7 +3,8 @@
     "loader": "framework:open_model",
     "fabric:type": "framework:open_model",
 	"textures": {
-		"sheep": "backpacked:backpack/sheep"
+		"sheep": "backpacked:backpack/sheep",
+		"particle": "#sheep"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/sheep_plush_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/sheep_plush_straps.json
@@ -3,7 +3,8 @@
     "loader": "framework:open_model",
     "fabric:type": "framework:open_model",
 	"textures": {
-		"sheep": "backpacked:backpack/sheep"
+		"sheep": "backpacked:backpack/sheep",
+		"particle": "#sheep"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/standard.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/standard.json
@@ -4,7 +4,8 @@
     "fabric:type": "framework:open_model",
 	"texture_size": [32, 16],
 	"textures": {
-		"standard": "backpacked:backpack/standard"
+		"standard": "backpacked:backpack/standard",
+		"particle": "#standard"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/standard_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/standard_straps.json
@@ -3,7 +3,8 @@
     "loader": "framework:open_model",
     "fabric:type": "framework:open_model",
 	"textures": {
-		"standard": "backpacked:backpack/standard"
+		"standard": "backpacked:backpack/standard",
+		"particle": "#standard"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/trash_can.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/trash_can.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"trash_can": "backpacked:backpack/trash_can"
+		"trash_can": "backpacked:backpack/trash_can",
+		"particle": "#trash_can"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/trash_can_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/trash_can_straps.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"trash_can": "backpacked:backpack/trash_can"
+		"trash_can": "backpacked:backpack/trash_can",
+		"particle": "#trash_can"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/turtle_shell.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/turtle_shell.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"turtle_shell": "backpacked:backpack/turtle_shell"
+		"turtle_shell": "backpacked:backpack/turtle_shell",
+		"particle": "#turtle_shell"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/turtle_shell_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/turtle_shell_straps.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"turtle_shell": "backpacked:backpack/turtle_shell"
+		"turtle_shell": "backpacked:backpack/turtle_shell",
+		"particle": "#turtle_shell"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/vintage.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/vintage.json
@@ -4,7 +4,8 @@
     "fabric:type": "framework:open_model",
 	"texture_size": [32, 32],
 	"textures": {
-		"vintage": "backpacked:backpack/vintage"
+		"vintage": "backpacked:backpack/vintage",
+		"particle": "#vintage"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/vintage_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/vintage_straps.json
@@ -4,7 +4,8 @@
     "fabric:type": "framework:open_model",
 	"texture_size": [32, 32],
 	"textures": {
-		"vintage": "backpacked:backpack/vintage"
+		"vintage": "backpacked:backpack/vintage",
+		"particle": "#vintage"
 	},
 	"components": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/wandering_bag.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/wandering_bag.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"wandering_bag": "backpacked:backpack/wandering_bag"
+		"wandering_bag": "backpacked:backpack/wandering_bag",
+		"particle": "#wandering_bag"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/assets/backpacked/models/backpacked/wandering_bag_straps.json
+++ b/common/src/main/resources/assets/backpacked/models/backpacked/wandering_bag_straps.json
@@ -1,7 +1,8 @@
 {
 	"credit": "Model by MrCrayfish (https://x.com/MrCrayfish) using Blockbench. All Rights Reserved.",
 	"textures": {
-		"wandering_bag": "backpacked:backpack/wandering_bag"
+		"wandering_bag": "backpacked:backpack/wandering_bag",
+		"particle": "#wandering_bag"
 	},
 	"elements": [
 		{

--- a/common/src/main/resources/backpacked.common.mixins.json
+++ b/common/src/main/resources/backpacked.common.mixins.json
@@ -3,7 +3,6 @@
     "minVersion": "0.8",
     "package": "com.mrcrayfish.backpacked.mixin",
     "compatibilityLevel": "JAVA_17",
-    "refmap": "backpacked.refmap.json",
     "mixins": [
         "common.AbstractArrowMixin",
         "common.BlockItemInvoker",

--- a/fabric/build.gradle
+++ b/fabric/build.gradle
@@ -55,9 +55,6 @@ loom {
     if (aw.exists()) {
         accessWidenerPath.set(aw)
     }
-    mixin {
-        defaultRefmapName.set("${mod_id}.refmap.json")
-    }
     runs {
         client {
             client()

--- a/fabric/src/main/resources/backpacked.fabric.mixins.json
+++ b/fabric/src/main/resources/backpacked.fabric.mixins.json
@@ -3,7 +3,6 @@
     "minVersion": "0.8",
     "package": "com.mrcrayfish.backpacked.mixin",
     "compatibilityLevel": "JAVA_17",
-    "refmap": "backpacked.refmap.json",
     "mixins": [
         "BlockMixin",
         "EntityMixin",


### PR DESCRIPTION
## Summary

- Add explicit `particle` texture references to the standalone backpack models, reusing each model's existing texture alias.
- Remove Backpacked's stale Fabric refmap declarations now that the build does not generate or package `backpacked.refmap.json`.
- Leave unrelated dependency warnings from other mods untouched.

## Rationale

This is intended to be a small resource/build cleanup for Fabric 26.1.2 startup noise. The model changes do not alter geometry, texture paths, rendering code, compatibility hooks, or gameplay behavior; they only provide the `particle` reference expected by the model baker. The refmap cleanup removes declarations for a file that is not produced by the current Fabric/Loom setup.

I intentionally avoided adding logs, fallbacks, helper abstractions, reflection, or compatibility reimplementations.

## Testing

- Tested in a Minecraft 26.1.2 Fabric instance and confirmed the Backpacked model `particle` warnings no longer appear.
- Confirmed the Backpacked `backpacked.refmap.json` warnings no longer appear.
- Verified all `assets/backpacked/models/backpacked/*.json` files parse as valid JSON.
- Verified the built jar contains the generated `backpack_dock` recipe, advancement, and loot table data.
- Ran Fabric datagen and build locally. In my checkout, I used a temporary local Gradle `flatDir` to resolve unavailable dependency artifacts without modifying the repository Gradle files.

## AI Assistance

This PR was prepared with AI assistance. I reviewed the resulting diff, kept the scope intentionally narrow, and tested the built jar locally before submitting. I take responsibility for the change and am happy to adjust it if there is a preferred project convention for these resources.
